### PR TITLE
Add assert statements to Spark

### DIFF
--- a/spark_save_file.txt
+++ b/spark_save_file.txt
@@ -2,3 +2,4 @@ T @@@ false @@@ buy milk
 D @@@ true @@@ destroy halo @@@ 1-22-2023 1600
 T @@@ false @@@ buy milk
 T @@@ false @@@ buy milk
+T @@@ false @@@ sell milk

--- a/src/main/java/spark/parser/Parser.java
+++ b/src/main/java/spark/parser/Parser.java
@@ -17,7 +17,7 @@ import spark.parser.params.AddTodoParams;
  */
 public class Parser {
     /** Specifies the accepted input-format for dates and times */
-    private static final DateTimeFormatter inputDateTimeFormatter = DateTimeFormatter.ofPattern("M-d-yyyy Hmm");
+    private static final DateTimeFormatter INPUT_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("M-d-yyyy Hmm");
 
     /**
      * Returns a Command specific to the type of operation
@@ -31,34 +31,26 @@ public class Parser {
         String commandKeyword = tokens[0]; // assume that the first keyword is always the command word
         CommandKeyword keyword = CommandKeyword.getCommand(commandKeyword);
 
-        if (keyword == CommandKeyword.BYE) {
+        switch (keyword) {
+        case BYE:
             return new ExitCommand();
-
-        } else if (keyword == CommandKeyword.LIST) {
+        case LIST:
             return new ListCommand();
-
-        } else if (keyword == CommandKeyword.MARK) {
+        case MARK:
             return new MarkCommand(getMarkParams(input, keyword));
-
-        } else if (keyword == CommandKeyword.UNMARK) {
+        case UNMARK:
             return new UnMarkCommand(getUnmarkParams(input, keyword));
-
-        } else if (keyword == CommandKeyword.DELETE) {
+        case DELETE:
             return new DeleteTaskCommand(getDeleteTaskParams(input, keyword));
-
-        } else if (keyword == CommandKeyword.TODO) {
+        case TODO:
             return new AddTodoCommand(getAddToDoParams(input, keyword));
-
-        } else if (keyword == CommandKeyword.DEADLINE) {
+        case DEADLINE:
             return new AddDeadlineCommand(getAddDeadlineParams(input, keyword));
-
-        } else if (keyword == CommandKeyword.EVENT) {
+        case EVENT:
             return new AddEventCommand(getAddEventParams(input, keyword));
-
-        } else if (keyword == CommandKeyword.FIND) {
+        case FIND:
             return new FindTaskCommand(getFindTaskParams(input, keyword));
-
-        } else {
+        default:
             return new UnrecognisedCommand();
         }
     }
@@ -110,7 +102,7 @@ public class Parser {
         LocalDateTime localDateTime;
 
         try {
-            localDateTime = LocalDateTime.parse(dateTimeString, inputDateTimeFormatter);
+            localDateTime = LocalDateTime.parse(dateTimeString, INPUT_DATE_TIME_FORMATTER);
         } catch (DateTimeParseException e) {
             throw new InvalidDeadlineParamsException();
         }
@@ -136,7 +128,7 @@ public class Parser {
         LocalDateTime localDateTime;
 
         try {
-            localDateTime = LocalDateTime.parse(dateTimeString, inputDateTimeFormatter);
+            localDateTime = LocalDateTime.parse(dateTimeString, INPUT_DATE_TIME_FORMATTER);
         } catch (DateTimeParseException e) {
             throw new InvalidEventParamsException();
         }

--- a/src/main/java/spark/ui/MainWindow.java
+++ b/src/main/java/spark/ui/MainWindow.java
@@ -39,8 +39,7 @@ public class MainWindow extends AnchorPane {
 
     private void showInitialisationMessage() {
         String welcomeMessage = "Greetings, erm, reclaimer...?" + "\n"
-                + "(why does he look so weird?)" + "\n\n"
-                + "Here are your tasks.";
+                + "(why does he look so weird?)" + "\n";
         String listOfTasks = spark.executeCommand("list");
         dialogContainer.getChildren().addAll(
                 SparkDialogBox.getSparkDialog(welcomeMessage, sparkImage)

--- a/src/main/java/spark/ui/SparkDialogBox.java
+++ b/src/main/java/spark/ui/SparkDialogBox.java
@@ -26,6 +26,8 @@ public class SparkDialogBox extends HBox {
     private ImageView displayPicture;
 
     SparkDialogBox(String text, Image img) {
+        assert(text != null);
+        assert(img != null);
         try {
             FXMLLoader fxmlLoader = new FXMLLoader(MainWindow.class.getResource("/view/SparkDialogBox.fxml"));
             fxmlLoader.setController(this);

--- a/src/main/java/spark/ui/UserDialogBox.java
+++ b/src/main/java/spark/ui/UserDialogBox.java
@@ -26,6 +26,8 @@ public class UserDialogBox extends HBox {
     private ImageView displayPicture;
 
     UserDialogBox(String text, Image img) {
+        assert(text != null);
+        assert(img != null);
         try {
             FXMLLoader fxmlLoader = new FXMLLoader(MainWindow.class.getResource("/view/UserDialogBox.fxml"));
             fxmlLoader.setController(this);
@@ -37,16 +39,6 @@ public class UserDialogBox extends HBox {
 
         dialog.setText(text);
         displayPicture.setImage(img);
-    }
-
-    /**
-     * Flips the dialog box such that the ImageView is on the left and text on the right.
-     */
-    private void flip() {
-        ObservableList<Node> tmp = FXCollections.observableArrayList(this.getChildren());
-        Collections.reverse(tmp);
-        getChildren().setAll(tmp);
-        setAlignment(Pos.TOP_LEFT);
     }
 
     public static UserDialogBox getUserDialog(String text, Image img) {


### PR DESCRIPTION
Constructor in DialogBox does not check that the input parameters are not null.

When null values are passed into DialogBox constructors, an unintelligible error message is printed to the console, making it difficult for developers to debug.

This situation may occur when the image to be included in the dialog box fails to be loaded by the program. This violates the basic assumption that all the required assets will be successfully loaded by the program.

To help make such an error easier to spot, let's add an explicit assertion to check that the image object is non-null.