### PR TITLE
Wrap result of command execution inside class CommandResponse

### DIFF
--- a/spark_save_file.txt
+++ b/spark_save_file.txt
@@ -1,4 +1,5 @@
 T @@@ false @@@ buy milk
-D @@@ true @@@ destroy halo @@@ 1-22-2023 1600
 T @@@ false @@@ buy milk
+T @@@ false @@@ buy milk
+T @@@ true @@@ buy milk
 T @@@ false @@@ buy milk

--- a/src/main/java/spark/Main.java
+++ b/src/main/java/spark/Main.java
@@ -23,7 +23,7 @@ public class Main extends Application {
             AnchorPane ap = fxmlLoader.load();
             Scene scene = new Scene(ap);
             // change the font
-            scene.getRoot().setStyle("-fx-font-family: Courier; -fx-font-size: 20");
+            scene.getRoot().setStyle("-fx-font-family: Courier; -fx-font-size: 18");
             stage.setScene(scene);
 
             fxmlLoader.<MainWindow>getController().setSpark(spark);

--- a/src/main/java/spark/commandresponse/CommandResponse.java
+++ b/src/main/java/spark/commandresponse/CommandResponse.java
@@ -1,0 +1,25 @@
+package spark.commandresponse;
+
+/**
+ * Encapsulates the result produced by Spark after running a Command
+ */
+public abstract class CommandResponse {
+    private String message;
+
+    /**
+     * Creates a new Command instance containing
+     * the specified message to be displayed to the user
+     * in the GUI.
+     *
+     * @param message
+     */
+    public CommandResponse(String message) {
+        this.message = message;
+    }
+    public String getMessage() {
+        return this.message;
+    }
+    public abstract boolean isWarning();
+    public abstract boolean isError();
+    public abstract boolean isExit();
+}

--- a/src/main/java/spark/commandresponse/ErrorResponse.java
+++ b/src/main/java/spark/commandresponse/ErrorResponse.java
@@ -1,0 +1,32 @@
+package spark.commandresponse;
+
+import spark.exceptions.SparkException;
+
+/**
+ * Encapsulates the result of running a Command unsuccessfully
+ */
+public class ErrorResponse extends CommandResponse {
+    /**
+     * Creates a new ErrorResponse instance containing
+     * the error message to be displayed to the user
+     * in the GUI.
+     *
+     * @param error
+     */
+    public ErrorResponse(SparkException error) {
+        super(error.getMessage());
+    }
+
+    @Override
+    public boolean isWarning() {
+        return false;
+    }
+    @Override
+    public boolean isError() {
+        return true;
+    }
+    @Override
+    public boolean isExit() {
+        return false;
+    }
+}

--- a/src/main/java/spark/commandresponse/ExitResponse.java
+++ b/src/main/java/spark/commandresponse/ExitResponse.java
@@ -1,0 +1,28 @@
+package spark.commandresponse;
+
+/**
+ * Encapsulates the result of running a Command successfully.
+ */
+public class ExitResponse extends CommandResponse {
+    private static final String GOODBYE_MESSAGE = "Okay bye!";
+    /**
+     * Creates a new ExitResponse instance containing
+     * the goodbye message to be shown to the user
+     * before exiting.
+     */
+    public ExitResponse() {
+        super(GOODBYE_MESSAGE);
+    }
+    @Override
+    public boolean isWarning() {
+        return false;
+    }
+    @Override
+    public boolean isError() {
+        return false;
+    }
+    @Override
+    public boolean isExit() {
+        return true;
+    }
+}

--- a/src/main/java/spark/commandresponse/SuccessResponse.java
+++ b/src/main/java/spark/commandresponse/SuccessResponse.java
@@ -1,0 +1,29 @@
+package spark.commandresponse;
+
+/**
+ * Encapsulates the result of running a Command successfully.
+ */
+public class SuccessResponse extends CommandResponse {
+    /**
+     * Creates a new SuccessResponse instance containing
+     * the specified message to be displayed to the user
+     * in the GUI.
+     *
+     * @param message
+     */
+    public SuccessResponse(String message) {
+        super(message);
+    }
+    @Override
+    public boolean isWarning() {
+        return false;
+    }
+    @Override
+    public boolean isError() {
+        return false;
+    }
+    @Override
+    public boolean isExit() {
+        return false;
+    }
+}

--- a/src/main/java/spark/commandresponse/WarningResponse.java
+++ b/src/main/java/spark/commandresponse/WarningResponse.java
@@ -1,0 +1,30 @@
+package spark.commandresponse;
+
+/**
+ * Encapsulates the result of running a Command that runs successfully
+ * but may potentially have some error.
+ */
+public class WarningResponse extends CommandResponse {
+    /**
+     * Creates a new WarningResponse instance containing
+     * the specified message to be displayed to the user
+     * in the GUI.
+     *
+     * @param message
+     */
+    public WarningResponse(String message) {
+        super(message);
+    }
+    @Override
+    public boolean isWarning() {
+        return true;
+    }
+    @Override
+    public boolean isError() {
+        return false;
+    }
+    @Override
+    public boolean isExit() {
+        return false;
+    }
+}

--- a/src/main/java/spark/parser/commands/commandtypes/AddDeadlineCommand.java
+++ b/src/main/java/spark/parser/commands/commandtypes/AddDeadlineCommand.java
@@ -1,8 +1,13 @@
 package spark.parser.commands.commandtypes;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import spark.Ui;
+import spark.commandresponse.CommandResponse;
+import spark.commandresponse.ErrorResponse;
+import spark.commandresponse.SuccessResponse;
 import spark.exceptions.SparkException;
 import spark.parser.params.AddDeadlineParams;
 import spark.storage.Storage;
@@ -27,24 +32,20 @@ public class AddDeadlineCommand extends Command {
     }
 
     @Override
-    public String execute(TaskList tasks, Ui ui, Storage storage) {
+    public List<CommandResponse> execute(TaskList tasks, Ui ui, Storage storage) {
+        List<CommandResponse> responses = new ArrayList<>();
+
         try {
             tasks.addDeadline(title, by);
             storage.writeTasksFile(tasks.encodeTasks());
             responseMessage = getAddTaskSuccessMessage(tasks);
-            ui.printMessageWithDivider(responseMessage);
 
-            return responseMessage;
+            responses.add(new SuccessResponse(responseMessage));
         } catch (SparkException e) {
-            ui.printException(e);
-
-            return e.getMessage();
+            responses.add(new ErrorResponse(e));
         }
-    }
 
-    @Override
-    public boolean isExit() {
-        return false;
+        return responses;
     }
 
     private String getAddTaskSuccessMessage(TaskList tasks) {

--- a/src/main/java/spark/parser/commands/commandtypes/AddEventCommand.java
+++ b/src/main/java/spark/parser/commands/commandtypes/AddEventCommand.java
@@ -1,12 +1,17 @@
 package spark.parser.commands.commandtypes;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import spark.Ui;
+import spark.commandresponse.CommandResponse;
+import spark.commandresponse.ErrorResponse;
+import spark.commandresponse.SuccessResponse;
 import spark.exceptions.SparkException;
 import spark.parser.params.AddEventParams;
 import spark.storage.Storage;
 import spark.tasks.TaskList;
-import spark.Ui;
-
-import java.time.LocalDateTime;
 
 /**
  * Represents a command to add a new event to the task list.
@@ -27,23 +32,20 @@ public class AddEventCommand extends Command {
     }
 
     @Override
-    public String execute(TaskList tasks, Ui ui, Storage storage) {
+    public List<CommandResponse> execute(TaskList tasks, Ui ui, Storage storage) {
+        List<CommandResponse> responses = new ArrayList<>();
+
         try {
             tasks.addEvent(title, at);
             storage.writeTasksFile(tasks.encodeTasks());
             responseMessage = getAddTaskSuccessMessage(tasks);
-            ui.printMessageWithDivider(responseMessage);
 
-            return responseMessage;
+            responses.add(new SuccessResponse(responseMessage));
         } catch (SparkException e) {
-            ui.printException(e);
-            return e.getMessage();
+            responses.add(new ErrorResponse(e));
         }
-    }
 
-    @Override
-    public boolean isExit() {
-        return false;
+        return responses;
     }
 
     private String getAddTaskSuccessMessage(TaskList tasks) {

--- a/src/main/java/spark/parser/commands/commandtypes/AddTodoCommand.java
+++ b/src/main/java/spark/parser/commands/commandtypes/AddTodoCommand.java
@@ -1,6 +1,12 @@
 package spark.parser.commands.commandtypes;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import spark.Ui;
+import spark.commandresponse.CommandResponse;
+import spark.commandresponse.ErrorResponse;
+import spark.commandresponse.SuccessResponse;
 import spark.exceptions.SparkException;
 import spark.parser.params.AddTodoParams;
 import spark.storage.Storage;
@@ -23,23 +29,20 @@ public class AddTodoCommand extends Command {
     }
 
     @Override
-    public String execute(TaskList tasks, Ui ui, Storage storage) {
+    public List<CommandResponse> execute(TaskList tasks, Ui ui, Storage storage) {
+        List<CommandResponse> responses = new ArrayList<>();
+
         try {
             tasks.addTodo(title);
             storage.writeTasksFile(tasks.encodeTasks());
             responseMessage = getAddTaskSuccessMessage(tasks);
-            ui.printMessageWithDivider(responseMessage);
 
-            return responseMessage;
+            responses.add(new SuccessResponse(responseMessage));
         } catch (SparkException e) {
-            ui.printException(e);
-            return e.getMessage();
+            responses.add(new ErrorResponse(e));
         }
-    }
 
-    @Override
-    public boolean isExit() {
-        return false;
+        return responses;
     }
 
     private String getAddTaskSuccessMessage(TaskList tasks) {

--- a/src/main/java/spark/parser/commands/commandtypes/Command.java
+++ b/src/main/java/spark/parser/commands/commandtypes/Command.java
@@ -1,6 +1,9 @@
 package spark.parser.commands.commandtypes;
 
+import java.util.List;
+
 import spark.Ui;
+import spark.commandresponse.CommandResponse;
 import spark.storage.Storage;
 import spark.tasks.TaskList;
 
@@ -9,7 +12,5 @@ import spark.tasks.TaskList;
  * All valid commands are sub-classes of this class.
  */
 public abstract class Command {
-    public abstract String execute(TaskList tasks, Ui ui, Storage storage);
-
-    public abstract boolean isExit();
+    public abstract List<CommandResponse> execute(TaskList tasks, Ui ui, Storage storage);
 }

--- a/src/main/java/spark/parser/commands/commandtypes/DeleteTaskCommand.java
+++ b/src/main/java/spark/parser/commands/commandtypes/DeleteTaskCommand.java
@@ -1,6 +1,12 @@
 package spark.parser.commands.commandtypes;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import spark.Ui;
+import spark.commandresponse.CommandResponse;
+import spark.commandresponse.ErrorResponse;
+import spark.commandresponse.SuccessResponse;
 import spark.exceptions.SparkException;
 import spark.storage.Storage;
 import spark.tasks.TaskList;
@@ -23,22 +29,20 @@ public class DeleteTaskCommand extends Command {
     }
 
     @Override
-    public String execute(TaskList tasks, Ui ui, Storage storage) {
+    public List<CommandResponse> execute(TaskList tasks, Ui ui, Storage storage) {
+        List<CommandResponse> responses = new ArrayList<>();
+
         try {
             tasks.deleteTask(index);
             storage.writeTasksFile(tasks.encodeTasks());
             responseMessage = getDeleteTaskSuccessMessage(tasks);
-            ui.printMessageWithDivider(responseMessage);
-            return responseMessage;
-        } catch (SparkException e) {
-            ui.printException(e);
-            return e.getMessage();
-        }
-    }
 
-    @Override
-    public boolean isExit() {
-        return false;
+            responses.add(new SuccessResponse(responseMessage));
+        } catch (SparkException e) {
+            responses.add(new ErrorResponse(e));
+        }
+
+        return responses;
     }
 
     private String getDeleteTaskSuccessMessage(TaskList tasks) {

--- a/src/main/java/spark/parser/commands/commandtypes/ExitCommand.java
+++ b/src/main/java/spark/parser/commands/commandtypes/ExitCommand.java
@@ -1,6 +1,11 @@
 package spark.parser.commands.commandtypes;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import spark.Ui;
+import spark.commandresponse.CommandResponse;
+import spark.commandresponse.ExitResponse;
 import spark.storage.Storage;
 import spark.tasks.TaskList;
 
@@ -11,14 +16,11 @@ public class ExitCommand extends Command {
     private String responseMessage;
 
     @Override
-    public String execute(TaskList tasks, Ui ui, Storage storage) {
-        responseMessage = "Cool, see you around!";
-        ui.printMessageWithDivider(responseMessage);
-        return responseMessage;
-    }
+    public List<CommandResponse> execute(TaskList tasks, Ui ui, Storage storage) {
+        List<CommandResponse> responses = new ArrayList<>();
 
-    @Override
-    public boolean isExit() {
-        return true;
+        responses.add(new ExitResponse());
+
+        return responses;
     }
 }

--- a/src/main/java/spark/parser/commands/commandtypes/FindTaskCommand.java
+++ b/src/main/java/spark/parser/commands/commandtypes/FindTaskCommand.java
@@ -1,8 +1,12 @@
 package spark.parser.commands.commandtypes;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import spark.Ui;
+import spark.commandresponse.CommandResponse;
+import spark.commandresponse.SuccessResponse;
+import spark.commandresponse.WarningResponse;
 import spark.storage.Storage;
 import spark.tasks.TaskList;
 import spark.tasks.tasktypes.Task;
@@ -26,12 +30,20 @@ public class FindTaskCommand extends Command {
     }
 
     @Override
-    public String execute(TaskList tasks, Ui ui, Storage storage) {
+    public List<CommandResponse> execute(TaskList tasks, Ui ui, Storage storage) {
+        List<CommandResponse> responses = new ArrayList<>();
+        responses.add(findAllMatchingTasks(tasks, searchTerm));
+        return responses;
+    }
+
+    private CommandResponse findAllMatchingTasks(TaskList tasks, String searchTerm) {
         List<Task> matches = tasks.findTask(searchTerm);
 
         StringBuilder results = new StringBuilder();
+        String noMatchingTaskMessage = "I couldn't find anything that matches what you are looking for.";
+
         if (matches.isEmpty()) {
-            results.append("I couldn't find anything that matches what you are looking for.");
+            return new WarningResponse(noMatchingTaskMessage);
         } else {
             results.append("Okay, I've found these tasks: ");
             results.append(System.lineSeparator());
@@ -43,14 +55,6 @@ public class FindTaskCommand extends Command {
             }
         }
 
-        responseMessage = results.toString();
-        ui.printMessageWithDivider(responseMessage);
-
-        return responseMessage;
-    }
-
-    @Override
-    public boolean isExit() {
-        return false;
+        return new SuccessResponse(results.toString());
     }
 }

--- a/src/main/java/spark/parser/commands/commandtypes/ListCommand.java
+++ b/src/main/java/spark/parser/commands/commandtypes/ListCommand.java
@@ -1,24 +1,32 @@
 package spark.parser.commands.commandtypes;
 
 import spark.Ui;
+import spark.commandresponse.CommandResponse;
+import spark.commandresponse.SuccessResponse;
+import spark.commandresponse.WarningResponse;
 import spark.storage.Storage;
 import spark.tasks.TaskList;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Represents a command for Spark to list all Tasks in the task-list.
  */
 public class ListCommand extends Command {
-    private String responseMessage;
-
     @Override
-    public String execute(TaskList tasks, Ui ui, Storage storage) {
-        responseMessage = tasks.getTaskList();
-        ui.printMessage(responseMessage);
-        return responseMessage;
-    }
+    public List<CommandResponse> execute(TaskList tasks, Ui ui, Storage storage) {
+        List<CommandResponse> responses = new ArrayList<>();
+        String noTasksMessage = "No tasks found! (trust me, I've looked everywhere)";
 
-    @Override
-    public boolean isExit() {
-        return false;
+        String allTaskTitles = tasks.getTaskList();
+
+        if (allTaskTitles.isBlank()) {
+            responses.add(new WarningResponse(noTasksMessage));
+        } else {
+            responses.add(new SuccessResponse(allTaskTitles));
+        }
+
+        return responses;
     }
 }

--- a/src/main/java/spark/parser/commands/commandtypes/MarkCommand.java
+++ b/src/main/java/spark/parser/commands/commandtypes/MarkCommand.java
@@ -1,6 +1,12 @@
 package spark.parser.commands.commandtypes;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import spark.Ui;
+import spark.commandresponse.CommandResponse;
+import spark.commandresponse.ErrorResponse;
+import spark.commandresponse.SuccessResponse;
 import spark.exceptions.SparkException;
 import spark.storage.Storage;
 import spark.tasks.TaskList;
@@ -23,22 +29,20 @@ public class MarkCommand extends Command {
     }
 
     @Override
-    public String execute(TaskList tasks, Ui ui, Storage storage) {
+    public List<CommandResponse> execute(TaskList tasks, Ui ui, Storage storage) {
+        List<CommandResponse> responses = new ArrayList<>();
+
         try {
             tasks.markTask(index);
             storage.writeTasksFile(tasks.encodeTasks());
             responseMessage = getModifyTaskSuccessMessage(tasks);
-            ui.printMessageWithDivider(responseMessage);
-            return responseMessage;
-        } catch (SparkException e) {
-            ui.printException(e);
-            return e.getMessage();
-        }
-    }
 
-    @Override
-    public boolean isExit() {
-        return false;
+            responses.add(new SuccessResponse(responseMessage));
+        } catch (SparkException e) {
+            responses.add(new ErrorResponse(e));
+        }
+
+        return responses;
     }
 
     private String getModifyTaskSuccessMessage(TaskList tasks) {

--- a/src/main/java/spark/parser/commands/commandtypes/UnMarkCommand.java
+++ b/src/main/java/spark/parser/commands/commandtypes/UnMarkCommand.java
@@ -1,6 +1,12 @@
 package spark.parser.commands.commandtypes;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import spark.Ui;
+import spark.commandresponse.CommandResponse;
+import spark.commandresponse.ErrorResponse;
+import spark.commandresponse.SuccessResponse;
 import spark.exceptions.SparkException;
 import spark.storage.Storage;
 import spark.tasks.TaskList;
@@ -23,22 +29,20 @@ public class UnMarkCommand extends Command {
     }
 
     @Override
-    public String execute(TaskList tasks, Ui ui, Storage storage) {
+    public List<CommandResponse> execute(TaskList tasks, Ui ui, Storage storage) {
+        List<CommandResponse> responses = new ArrayList<>();
+
         try {
             tasks.unMarkTask(index);
             storage.writeTasksFile(tasks.encodeTasks());
             responseMessage = getModifyTaskSuccessMessage(tasks);
-            ui.printMessageWithDivider(responseMessage);
-            return responseMessage;
-        } catch (SparkException e) {
-            ui.printException(e);
-            return e.getMessage();
-        }
-    }
 
-    @Override
-    public boolean isExit() {
-        return false;
+            responses.add(new SuccessResponse(responseMessage));
+        } catch (SparkException e) {
+            responses.add(new ErrorResponse(e));
+        }
+
+        return responses;
     }
 
     private String getModifyTaskSuccessMessage(TaskList tasks) {

--- a/src/main/java/spark/parser/commands/commandtypes/UnrecognisedCommand.java
+++ b/src/main/java/spark/parser/commands/commandtypes/UnrecognisedCommand.java
@@ -1,6 +1,11 @@
 package spark.parser.commands.commandtypes;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import spark.Ui;
+import spark.commandresponse.CommandResponse;
+import spark.commandresponse.ErrorResponse;
 import spark.exceptions.formatexceptions.UnrecognisedCommandException;
 import spark.storage.Storage;
 import spark.tasks.TaskList;
@@ -13,15 +18,13 @@ public class UnrecognisedCommand extends Command {
     private String responseMessage;
 
     @Override
-    public String execute(TaskList tasks, Ui ui, Storage storage) {
-        UnrecognisedCommandException e = new UnrecognisedCommandException();
-        responseMessage = e.getMessage();
-        ui.printException(e);
-        return responseMessage;
-    }
+    public List<CommandResponse> execute(TaskList tasks, Ui ui, Storage storage) {
+        List<CommandResponse> responses = new ArrayList<>();
 
-    @Override
-    public boolean isExit() {
-        return false;
+        UnrecognisedCommandException e = new UnrecognisedCommandException();
+
+        responses.add(new ErrorResponse(e));
+
+        return responses;
     }
 }

--- a/src/main/java/spark/tasks/TaskList.java
+++ b/src/main/java/spark/tasks/TaskList.java
@@ -106,17 +106,14 @@ public class TaskList {
     public String getTaskList() {
         // if there are no tasks, inform the user
         if (tasks.size() == 0) {
-            return "No tasks found! (trust me, I've looked everywhere)";
+            return "";
         } else {
             StringBuilder listOfTasks = new StringBuilder();
 
-            listOfTasks.append("\n"
-                    + "Here are your tasks:"
-                    + "\n"
-            );
+            listOfTasks.append("Here are your tasks:" + "\n");
 
             for (int i = 0; i < tasks.size(); i++) {
-                listOfTasks.append(String.format("    %d. %s\n", i + 1, tasks.get(i)));
+                listOfTasks.append(String.format("%d. %s\n", i + 1, tasks.get(i)));
             }
 
             return listOfTasks.toString();

--- a/src/main/java/spark/ui/DialogBox.java
+++ b/src/main/java/spark/ui/DialogBox.java
@@ -1,0 +1,50 @@
+package spark.ui;
+
+import javafx.geometry.Insets;
+import javafx.scene.image.Image;
+import javafx.scene.layout.Background;
+import javafx.scene.layout.BackgroundFill;
+import javafx.scene.layout.CornerRadii;
+import javafx.scene.layout.HBox;
+import javafx.scene.paint.Color;
+
+/**
+ * Represents a DialogBox that appears as a single chat-bubble
+ * sent by either the user or Spark on the GUI
+ */
+public abstract class DialogBox extends HBox {
+    protected static final Color NORMAL_CHATBOX_COLOR = Color.web("#FFFFFF");
+    protected static final Color SUCCESS_CHATBOX_COLOR = Color.web("#BEE5B0");
+    protected static final Color WARNING_CHATBOX_COLOR = Color.web("#F8F1AE");
+    protected static final Color ERROR_CHATBOX_COLOR = Color.web("#FFB2AE");
+
+    protected static Background getNormalChatboxColor() {
+        return new Background(
+                new BackgroundFill(
+                        DialogBox.NORMAL_CHATBOX_COLOR,
+                        new CornerRadii(20),
+                        new Insets(0)));
+    }
+
+    protected static Background getSuccessChatboxColor() {
+        return new Background(
+                new BackgroundFill(
+                        DialogBox.SUCCESS_CHATBOX_COLOR,
+                        new CornerRadii(20),
+                        new Insets(0)));
+    }
+
+    protected static Background getWarningChatboxColor() {
+        return new Background(
+                new BackgroundFill(DialogBox.WARNING_CHATBOX_COLOR,
+                        new CornerRadii(20),
+                        new Insets(0)));
+    }
+
+    protected static Background getErrorChatboxColor() {
+        return new Background(
+                new BackgroundFill(DialogBox.ERROR_CHATBOX_COLOR,
+                        new CornerRadii(20),
+                        new Insets(0)));
+    }
+}

--- a/src/main/java/spark/ui/SparkDialogBox.java
+++ b/src/main/java/spark/ui/SparkDialogBox.java
@@ -1,25 +1,19 @@
 package spark.ui;
 
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
+import java.io.IOException;
+
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
-import javafx.geometry.Pos;
-import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.layout.HBox;
-
-import java.io.IOException;
-import java.util.Collections;
 
 /**
  * An example of a custom control using FXML.
  * This control represents a dialog box consisting of an ImageView to represent the speaker's face and a label
  * containing text from the speaker.
  */
-public class SparkDialogBox extends HBox {
+public class SparkDialogBox extends DialogBox {
     @FXML
     private Label dialog;
     @FXML
@@ -39,17 +33,31 @@ public class SparkDialogBox extends HBox {
         displayPicture.setImage(img);
     }
 
-    /**
-     * Flips the dialog box such that the ImageView is on the left and text on the right.
-     */
-    private void flip() {
-        ObservableList<Node> tmp = FXCollections.observableArrayList(this.getChildren());
-        Collections.reverse(tmp);
-        getChildren().setAll(tmp);
-        setAlignment(Pos.TOP_LEFT);
+    public static DialogBox getDialog(String text, Image img) {
+        SparkDialogBox dialogBox = new SparkDialogBox(text, img);
+        dialogBox.dialog.setBackground(DialogBox.getNormalChatboxColor());
+
+        return dialogBox;
     }
 
-    public static SparkDialogBox getSparkDialog(String text, Image img) {
-        return new SparkDialogBox(text, img);
+    public static SparkDialogBox getSuccessSparkDialog(String text, Image img) {
+        SparkDialogBox dialogBox = new SparkDialogBox(text, img);
+        dialogBox.dialog.setBackground(DialogBox.getSuccessChatboxColor());
+
+        return dialogBox;
+    }
+
+    public static SparkDialogBox getWarningSparkDialog(String text, Image img) {
+        SparkDialogBox dialogBox = new SparkDialogBox(text, img);
+        dialogBox.dialog.setBackground(DialogBox.getWarningChatboxColor());
+
+        return dialogBox;
+    }
+
+    public static SparkDialogBox getErrorSparkDialog(String text, Image img) {
+        SparkDialogBox dialogBox = new SparkDialogBox(text, img);
+        dialogBox.dialog.setBackground(DialogBox.getErrorChatboxColor());
+
+        return dialogBox;
     }
 }

--- a/src/main/java/spark/ui/UserDialogBox.java
+++ b/src/main/java/spark/ui/UserDialogBox.java
@@ -12,14 +12,13 @@ import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.layout.HBox;
 
 /**
  * An example of a custom control using FXML.
  * This control represents a dialog box consisting of an ImageView to represent the speaker's face and a label
  * containing text from the speaker.
  */
-public class UserDialogBox extends HBox {
+public class UserDialogBox extends DialogBox {
     @FXML
     private Label dialog;
     @FXML
@@ -39,17 +38,10 @@ public class UserDialogBox extends HBox {
         displayPicture.setImage(img);
     }
 
-    /**
-     * Flips the dialog box such that the ImageView is on the left and text on the right.
-     */
-    private void flip() {
-        ObservableList<Node> tmp = FXCollections.observableArrayList(this.getChildren());
-        Collections.reverse(tmp);
-        getChildren().setAll(tmp);
-        setAlignment(Pos.TOP_LEFT);
-    }
+    public static UserDialogBox getDialog(String text, Image img) {
+        UserDialogBox dialogBox = new UserDialogBox(text, img);
+        dialogBox.dialog.setBackground(DialogBox.getNormalChatboxColor());
 
-    public static UserDialogBox getUserDialog(String text, Image img) {
-        return new UserDialogBox(text, img);
+        return dialogBox;
     }
 }

--- a/src/main/resources/view/SparkDialogBox.fxml
+++ b/src/main/resources/view/SparkDialogBox.fxml
@@ -4,18 +4,14 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.StackPane?>
 
 <fx:root alignment="CENTER_LEFT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefWidth="580.0" spacing="10.0" type="javafx.scene.layout.HBox" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
     <children>
-      <HBox alignment="CENTER_LEFT" prefWidth="500.0" style="-fx-background-color: c4fafb c4fafb; -fx-background-radius: 10;">
-         <children>
-              <ImageView fx:id="displayPicture" fitHeight="99.0" fitWidth="99.0" pickOnBounds="true" preserveRatio="true" />
-              <Label fx:id="dialog" text="Label" wrapText="true" />
-         </children>
-         <padding>
-            <Insets bottom="20.0" top="20.0" />
-         </padding>
-      </HBox>
+        <StackPane style="-fx-background-radius: 20; -fx-background-color: #FFFFFF; -fx-min-height: 110; -fx-min-width: 110; -fx-max-height: 110; -fx-max-width: 110">
+            <ImageView fx:id="displayPicture" fitHeight="99.0" fitWidth="99.0" pickOnBounds="true" preserveRatio="true" />
+        </StackPane>
+        <Label fx:id="dialog" style="-fx-label-padding: 20;" text="Label" wrapText="true" />
     </children>
     <padding>
         <Insets bottom="15.0" left="5.0" right="5.0" top="15.0" />

--- a/src/main/resources/view/UserDialogBox.fxml
+++ b/src/main/resources/view/UserDialogBox.fxml
@@ -4,15 +4,14 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.StackPane?>
 
 <fx:root alignment="CENTER_RIGHT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefWidth="580.0" spacing="10.0" type="javafx.scene.layout.HBox" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
     <children>
-      <HBox alignment="CENTER_RIGHT" prefWidth="500.0" style="-fx-background-color: c4fafb c4fafb; -fx-background-radius: 10;">
-         <children>
-              <Label fx:id="dialog" text="Label" wrapText="true" />
-              <ImageView fx:id="displayPicture" fitHeight="99.0" fitWidth="99.0" pickOnBounds="true" preserveRatio="true" />
-         </children>
-      </HBox>
+        <Label fx:id="dialog" text="Label" wrapText="true" style="-fx-label-padding: 20;" />
+        <StackPane style="-fx-background-radius: 20; -fx-background-color: #FFFFFF; -fx-min-height: 110; -fx-min-width: 110; -fx-max-height: 110; -fx-max-width: 110">
+            <ImageView fx:id="displayPicture" fitHeight="99.0" fitWidth="99.0" pickOnBounds="true" preserveRatio="true" />
+        </StackPane>
     </children>
     <padding>
         <Insets bottom="15.0" left="5.0" right="5.0" top="15.0" />


### PR DESCRIPTION
When a Command is executed by Spark, only a String object containing the response message is generated. This restricts metadata that can be specified about the response of the executed Command; such as whether it was produced as a result of a successful execution of the given Command, or if it was produced because of an exception produced when the Command was run.

Without this metadata, the user-interface cannot tailor the color of the chat box produced; ie it would not be possible to produce a red-colored chat box to indicate to the user that the input command could not be executed successfully.

To allow such additional information to be added, let's encapsulate the result of a Command into a class that not only contains the message to be shown to the user, and also other attributes of the result of the command's execution like whether it is an error, or if it is a warning that indicates some possibly undesirable impact resulting from its execution.

Doing so would provide additional visual feedback to the user about the result of the command's execution.